### PR TITLE
Make it automatically load the default splits

### DIFF
--- a/wwwsplit.js
+++ b/wwwsplit.js
@@ -643,6 +643,10 @@ var run = {
 $(document).ready(function() {
 	run.data = JSON.parse(localStorage.getItem('data'));
 
+	if (run.data == null) {
+		run.data = data;
+	}
+
 	/*
 	run.data = data;
 	localStorage.setItem('data', JSON.stringify(run.data, run.replacer));

--- a/wwwsplit.js
+++ b/wwwsplit.js
@@ -645,12 +645,8 @@ $(document).ready(function() {
 
 	if (run.data == null) {
 		run.data = data;
+		localStorage.setItem('data', JSON.stringify(run.data, run.replacer));
 	}
-
-	/*
-	run.data = data;
-	localStorage.setItem('data', JSON.stringify(run.data, run.replacer));
-	*/
 
 	run.generateRunTable();
 


### PR DESCRIPTION
If there's no splits stored in Local Storage, the Timer failed to load, so it's automatically loading the default splits in that case now.
